### PR TITLE
feat: 로그인 부터 첼린지 생성까지의 api 연동 및 middleware token 설정 setting 추가

### DIFF
--- a/app/(challenge)/(다짐 도전)/model/challenge/useChallengeData.ts
+++ b/app/(challenge)/(다짐 도전)/model/challenge/useChallengeData.ts
@@ -1,19 +1,11 @@
-import { useSession } from 'next-auth/react';
 import { useEffect, useState } from 'react';
 import challengeModel, { ButtonInfo } from './challengeModel';
 
 const useChallengeData = () => {
-  const { data } = useSession();
   const [buttonInfo, setButtonInfo] = useState<ButtonInfo>({
     text: '1일차 인증하기',
     link: '다짐_인증',
   });
-
-  useEffect(() => {
-    if (data) {
-      challengeModel.setSession(data);
-    }
-  }, [data]);
 
   useEffect(() => {
     const updateButtonInfo = () => {

--- a/app/(challenge)/(다짐 생성)/add/page.tsx
+++ b/app/(challenge)/(다짐 생성)/add/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+import RefreshCheck from '@/app/common/hooks/funnel/RefreshCheck';
 import { extractNonEmptyArrayKeys } from '@/app/common/hooks/funnel/models';
 import navigationPath from '@/app/common/navigation/navigationPath';
 import dayjs from 'dayjs';
@@ -47,25 +48,31 @@ const ChallengeAddFunnel = () => {
         />
       </Funnel.Step>
       <Funnel.Step name="기프티콘_업로드">
-        <BetPage
-          challenge={challenge}
-          setChallenge={setChallenge}
-          onNext={() => setStep('다짐_시작일')}
-        />
+        <RefreshCheck onRefresh={() => setStep('다짐_입력')}>
+          <BetPage
+            challenge={challenge}
+            setChallenge={setChallenge}
+            onNext={() => setStep('다짐_시작일')}
+          />
+        </RefreshCheck>
       </Funnel.Step>
       <Funnel.Step name="다짐_시작일">
-        <StartDatePage
-          challenge={challenge}
-          setChallenge={setChallenge}
-          onNext={() => setStep('다짐_등록_확인')}
-        />
+        <RefreshCheck onRefresh={() => setStep('다짐_입력')}>
+          <StartDatePage
+            challenge={challenge}
+            setChallenge={setChallenge}
+            onNext={() => setStep('다짐_등록_확인')}
+          />
+        </RefreshCheck>
       </Funnel.Step>
       <Funnel.Step name="다짐_등록_확인">
-        <PreviewPage
-          challenge={challenge}
-          setChallenge={setChallenge}
-          onNext={() => setStep('다짐_등록_완료')}
-        />
+        <RefreshCheck onRefresh={() => setStep('다짐_입력')}>
+          <PreviewPage
+            challenge={challenge}
+            setChallenge={setChallenge}
+            onNext={() => setStep('다짐_등록_완료')}
+          />
+        </RefreshCheck>
       </Funnel.Step>
       <Funnel.Step name="다짐_등록_완료">
         <ResultPage

--- a/app/(challenge)/(다짐 생성)/add/page.tsx
+++ b/app/(challenge)/(다짐 생성)/add/page.tsx
@@ -23,7 +23,7 @@ export interface Challenge {
   gifticon: {
     file: File | null;
   };
-  startDate: dayjs.Dayjs | null;
+  startDate: dayjs.Dayjs;
 }
 
 const ChallengeAddFunnel = () => {
@@ -35,7 +35,7 @@ const ChallengeAddFunnel = () => {
     gifticon: {
       file: null,
     },
-    startDate: null,
+    startDate: dayjs().add(1, 'day'),
   });
 
   return (

--- a/app/(challenge)/(다짐 생성)/module/api/challenge.ts
+++ b/app/(challenge)/(다짐 생성)/module/api/challenge.ts
@@ -1,0 +1,53 @@
+import { withSessionUser } from '@/app/common/api/withSessionUser';
+import client from '@/app/common/api/client';
+import { useMutation } from '@tanstack/react-query';
+
+export interface Json {
+  isSuccess: boolean;
+  data: Data;
+  errorResponse: unknown;
+}
+export interface Data {
+  id: number;
+  type: string;
+  content: Content;
+  threshold: Threshold;
+  startDate: StartDate;
+  endDate: EndDate;
+}
+export interface Content {
+  value: string;
+}
+export interface Threshold {
+  value: number;
+}
+export type StartDate = number[];
+
+export type EndDate = number[];
+
+interface RequestInterface {
+  postData: {
+    type: 'FREE' | 'BILLING';
+    content: string;
+    startDate: string;
+    endDate: string;
+  };
+}
+
+const postChallengeAPI = withSessionUser(async ({ postData }: RequestInterface) => {
+  const { data } = await client<Json>({
+    method: 'post',
+    url: '/v1/api/goal',
+    data: postData,
+  });
+  return data;
+});
+
+const POST_CHALLENGE_KEY = () => ['challenge'];
+
+export const usePOSTChallengeQuery = () => {
+  return useMutation({
+    mutationKey: POST_CHALLENGE_KEY(),
+    mutationFn: postChallengeAPI,
+  });
+};

--- a/app/(challenge)/(다짐 생성)/module/preview/useHandlePreview.ts
+++ b/app/(challenge)/(다짐 생성)/module/preview/useHandlePreview.ts
@@ -1,0 +1,27 @@
+import dayjs from 'dayjs';
+import { ChallengeAddFunnelProps } from '../../add/page';
+import { usePOSTChallengeQuery } from '../api/challenge';
+
+type PickData = Pick<ChallengeAddFunnelProps, 'challenge'>;
+interface PreviewProps extends PickData {}
+
+const useHandlePreview = ({ challenge }: PreviewProps) => {
+  const { mutate } = usePOSTChallengeQuery();
+
+  const submit = () => {
+    mutate({
+      postData: {
+        type: 'FREE',
+        content: challenge.title,
+        startDate: dayjs(challenge.startDate).toISOString(),
+        endDate: dayjs(challenge.startDate).add(7, 'day').toISOString(),
+      },
+    });
+  };
+
+  return {
+    submit,
+  };
+};
+
+export default useHandlePreview;

--- a/app/(challenge)/(다짐 생성)/ui/Preview/PreviewPage.tsx
+++ b/app/(challenge)/(다짐 생성)/ui/Preview/PreviewPage.tsx
@@ -7,10 +7,10 @@ import {
   withPreWrapCenter,
 } from '@/app/common/ui/common.css';
 import { getDayPeriodToText } from '@/app/common/util/date';
-import dayjs from 'dayjs';
 import Image from 'next/image';
 import { Dispatch, SetStateAction } from 'react';
 import { Challenge, ChallengeAddFunnelProps } from '../../add/page';
+import useHandlePreview from '../../module/preview/useHandlePreview';
 import { previewPageStyles } from './preview.css';
 
 interface PreviewPageProps extends ChallengeAddFunnelProps {
@@ -19,9 +19,12 @@ interface PreviewPageProps extends ChallengeAddFunnelProps {
 }
 
 const PreviewPage = ({ challenge, onNext }: PreviewPageProps) => {
-  // TODO : 추후 새로고침 여부에 따라 첫 화면으로 넘길 것
-  const title = challenge.title ?? '한달동안 3kg 감량할거야';
-  const startDate = challenge.startDate ?? dayjs();
+  const { submit } = useHandlePreview({ challenge });
+
+  const onClickSubmit = () => {
+    submit();
+    onNext();
+  };
 
   return (
     <>
@@ -41,15 +44,15 @@ const PreviewPage = ({ challenge, onNext }: PreviewPageProps) => {
           />
         </div>
         <div className={previewPageStyles.challengeTextWrapper}>
-          <Text.BodyL>{title}</Text.BodyL>
-          <Text.BodyS color="grey400">{getDayPeriodToText(startDate, 7)}</Text.BodyS>
+          <Text.BodyL>{challenge.title}</Text.BodyL>
+          <Text.BodyS color="grey400">{getDayPeriodToText(challenge.startDate, 7)}</Text.BodyS>
         </div>
       </div>
       <BottomFixedButton>
         <BottomFixedButton.OverItem className={fixedButtonOverWrapper}>
           <Text.BodyM color="white">지금 등록하면 수정할 수 없어요!</Text.BodyM>
         </BottomFixedButton.OverItem>
-        <BottomFixedButton.First width={100} onClick={onNext}>
+        <BottomFixedButton.First width={100} onClick={onClickSubmit}>
           <Text.ButtonL>내기 등록 완료하기</Text.ButtonL>
         </BottomFixedButton.First>
       </BottomFixedButton>

--- a/app/api/auth/token.ts
+++ b/app/api/auth/token.ts
@@ -1,0 +1,39 @@
+import axios from 'axios';
+import { AuthUser } from './[...nextauth]/route';
+
+interface PostKakaoLogin {
+  accessToken: string;
+}
+
+interface PostKakaoLoginResponse {
+  data: AuthUser;
+}
+
+export const postToken = async ({ accessToken }: PostKakaoLogin) => {
+  const { data } = await axios.post<PostKakaoLoginResponse>(
+    `${process.env.NEXT_PUBLIC_API_URL}/v1/auth/login`,
+    {
+      accessToken,
+    },
+  );
+
+  return data;
+};
+
+interface PostRefreshTokenResponse {
+  data: {
+    accessToken: string;
+    refreshToken: string;
+  };
+}
+
+export const postRefreshToken = async ({ accessToken }: { accessToken: string }) => {
+  const { data } = await axios.post<PostRefreshTokenResponse>(
+    `${process.env.NEXT_PUBLIC_API_URL}/v1/auth/refresh`,
+    {
+      accessToken,
+    },
+  );
+
+  return data;
+};

--- a/app/common/api/client.ts
+++ b/app/common/api/client.ts
@@ -1,0 +1,29 @@
+import axios, { AxiosError, AxiosResponse } from 'axios';
+import { signIn } from 'next-auth/react';
+
+const client = axios.create({
+  baseURL: '',
+});
+
+client.interceptors.response.use(
+  (response: AxiosResponse): AxiosResponse => {
+    // 응답을 그대로 리턴
+    return response;
+  },
+  (error: AxiosError): Promise<never> => {
+    // Axios 에러 처리
+    if (error.response) {
+      if (error.response.status === 401) {
+        signIn('kakao', { redirect: false });
+      }
+    } else if (error.request) {
+      // 요청이 만들어졌지만 응답을 받지 못한 경우
+    } else {
+      // 요청을 만드는 중에 다른 오류가 발생한 경우
+    }
+    // 처리한 후 에러를 다시 throw
+    return Promise.reject(error);
+  },
+);
+
+export default client;

--- a/app/common/api/withSessionUser.ts
+++ b/app/common/api/withSessionUser.ts
@@ -1,0 +1,34 @@
+import { AxiosError, AxiosHeaders } from 'axios';
+import { getSession } from 'next-auth/react';
+import client from './client';
+
+export function withSessionUser<R>(handler: () => Promise<R>): () => Promise<R>;
+export function withSessionUser<T, R>(handler: (arg: T) => Promise<R>): (arg: T) => Promise<R>;
+
+export function withSessionUser<T, R>(
+  handler: (...args: T[]) => Promise<R>,
+): (...args: T[]) => Promise<R> {
+  return async (...args: T[]) => {
+    const session = await getSession();
+    if (!session || !session.user) {
+      const headers = new AxiosHeaders();
+
+      throw new AxiosError('Unauthorized', '401', undefined, null, {
+        data: 'Unauthorized',
+        status: 401,
+        statusText: 'Unauthorized',
+        config: {
+          headers,
+        },
+        headers: {},
+      });
+    }
+
+    // axios 기본 헤더 설정
+    if (client.defaults.headers.common.Authorization !== `Bearer ${session.user.accessToken}`) {
+      client.defaults.headers.common.Authorization = `Bearer ${session.user.accessToken}`;
+    }
+
+    return handler(...args);
+  };
+}

--- a/app/common/components/QueryProvider.tsx
+++ b/app/common/components/QueryProvider.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactNode, useState } from 'react';
+
+type Props = {
+  children: ReactNode;
+};
+
+const QueryProvider = ({ children }: Props) => {
+  const [client] = useState(
+    new QueryClient({
+      defaultOptions: {
+        queries: {
+          refetchOnWindowFocus: false,
+          retry: false,
+        },
+      },
+    }),
+  );
+
+  return (
+    <QueryClientProvider client={client}>
+      {children}
+      {/* <ReactQueryDevtools initialIsOpen={false} /> */}
+    </QueryClientProvider>
+  );
+};
+
+export default QueryProvider;

--- a/app/common/hooks/funnel/RefreshCheck.tsx
+++ b/app/common/hooks/funnel/RefreshCheck.tsx
@@ -1,0 +1,50 @@
+import { ReactNode, useEffect } from 'react';
+
+// value와 checkKey가 모두 있는 경우
+interface RefreshCheckPropsWithValues<T extends object> {
+  value: T;
+  checkKey: keyof T;
+  onRefresh: () => void;
+  children: ReactNode;
+}
+
+// value와 checkKey가 모두 없는 경우
+interface RefreshCheckPropsWithoutValues {
+  value?: never;
+  checkKey?: never;
+  onRefresh: () => void;
+  children: ReactNode;
+}
+
+function RefreshCheck<T extends object>(props: RefreshCheckPropsWithValues<T>): JSX.Element;
+function RefreshCheck(props: RefreshCheckPropsWithoutValues): JSX.Element;
+
+function RefreshCheck<T extends object>({
+  value,
+  checkKey,
+  onRefresh,
+  children,
+}: RefreshCheckPropsWithValues<T> | RefreshCheckPropsWithoutValues) {
+  useEffect(() => {
+    const isPageLoaded = sessionStorage.getItem('loaded');
+
+    if (!isPageLoaded) {
+      sessionStorage.setItem('loaded', 'true');
+    }
+
+    // 체크할 값이 있는 경우 해당 값이 없으면 새로고침
+    if (value && checkKey && isPageLoaded) {
+      if (!value[checkKey]) onRefresh();
+    }
+    // 체크할 값이 없는 경우 새로고침
+    if (!value && !checkKey && isPageLoaded) onRefresh();
+
+    return () => {
+      sessionStorage.removeItem('loaded');
+    };
+  }, [value, checkKey, onRefresh]);
+
+  return <>{children}</>;
+}
+
+export default RefreshCheck;

--- a/app/common/hooks/funnel/useFunnel.tsx
+++ b/app/common/hooks/funnel/useFunnel.tsx
@@ -63,9 +63,7 @@ export const useFunnel = <Steps extends NonEmptyArray<string>>(
   const step = useMemo(() => {
     const step = searchParams.get('step');
 
-    if (typeof step === 'string' && steps.includes(step)) {
-      return step;
-    }
+    if (typeof step === 'string' && steps.includes(step)) return step;
 
     return steps[0];
   }, [searchParams, steps]);
@@ -88,7 +86,7 @@ export const useFunnel = <Steps extends NonEmptyArray<string>>(
         },
       ),
 
-    [searchParams],
+    [step],
   );
 
   FunnelComponent.Step = Step;

--- a/app/common/navigation/navigationPath.ts
+++ b/app/common/navigation/navigationPath.ts
@@ -2,7 +2,7 @@ type 로그인_퍼널_Key = '로그인' | '닉네임_설정';
 
 const 로그인_퍼널: Record<로그인_퍼널_Key, string> = {
   로그인: '/login',
-  닉네임_설정: 'login?step=닉네임_설정',
+  닉네임_설정: '/login?step=닉네임_설정',
 };
 
 type 다짐_생성_퍼널_Key =

--- a/app/common/ui/Drawer/LoginDrawer.tsx
+++ b/app/common/ui/Drawer/LoginDrawer.tsx
@@ -1,12 +1,16 @@
 'use client';
+import { useSession } from 'next-auth/react';
 import Link from 'next/link';
 import navigationPath from '../../navigation/navigationPath';
 import Text from '../Text/Text';
 import Icon from '../assets/Icon';
 import { loginDrawerStyles } from './loginDrawer.css';
 
+// TODO : 로그인 상태 아니면 카카오 로그인 버튼 띄우기
+
 const LoginDrawer = () => {
-  const nickname = '용용';
+  const { data } = useSession();
+  const nickname = data?.user?.nickname;
   return (
     <div className={loginDrawerStyles.container}>
       <div className={loginDrawerStyles.headerTextWrapper}>

--- a/app/common/ui/TextArea/TextArea.tsx
+++ b/app/common/ui/TextArea/TextArea.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import React, { ChangeEvent, forwardRef, useState } from 'react';
+import React, { ChangeEvent, forwardRef } from 'react';
 import TextAreaAutoSize, { TextareaAutosizeProps } from 'react-textarea-autosize';
 import Text from '../Text/Text';
 import { ButtonIcon } from '../assets/Icon';
@@ -44,24 +44,20 @@ export type BaseProps = {
 
 const Base = forwardRef<HTMLTextAreaElement, BaseProps>(
   ({ value, onChange, withCount, className, ...rest }, ref) => {
-    const [count, setCount] = useState(value.length ?? 0);
-
     const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
       if (rest.maxRows && rest.maxRows === 1 && e.target.value.includes('\n')) return;
       if (withCount && e.target.value.length > withCount.max) return;
 
-      setCount(e.target.value.length);
       onChange(e);
     };
 
     const onClickClose = () => {
-      setCount(0);
       onChange({ target: { value: '' } } as ChangeEvent<HTMLTextAreaElement>);
     };
 
     const getCountVisible = () => {
       if (!withCount) return false;
-      if (count > 0) return true;
+
       return withCount.initialVisible ?? false;
     };
 
@@ -77,14 +73,14 @@ const Base = forwardRef<HTMLTextAreaElement, BaseProps>(
             required
             {...rest}
           />
-          {!!count && !rest.disabled && (
+          {!!value.length && !rest.disabled && (
             <ButtonIcon onClick={onClickClose} name="close-circle" size="m" fill="grey600" />
           )}
         </div>
         {getCountVisible() && (
           <div className={textAreaStyle.countContainerStyle}>
             <Text.BodyM color="grey600">
-              {count}/{withCount?.max}
+              {value.length}/{withCount?.max}
             </Text.BodyM>
           </div>
         )}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 import type { Metadata } from 'next';
 import localFont from 'next/font/local';
 import AuthSession from './common/components/AuthSession';
+import QueryProvider from './common/components/QueryProvider';
 import IconLoader from './common/ui/assets/IconLoader';
 import './common/ui/reset.css';
 import './globals.css';
@@ -34,8 +35,10 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
     <html lang="ko">
       <body className={classNames(pretendardFont.className, layoutStyle)}>
         <AuthSession>
-          <IconLoader />
-          {children}
+          <QueryProvider>
+            <IconLoader />
+            {children}
+          </QueryProvider>
         </AuthSession>
       </body>
     </html>

--- a/app/login/module/api/nickname.ts
+++ b/app/login/module/api/nickname.ts
@@ -1,0 +1,45 @@
+import { withSessionUser } from '@/app/common/api/withSessionUser';
+import client from '@/app/common/api/client';
+import { useMutation } from '@tanstack/react-query';
+
+export interface Json {
+  isSuccess: boolean;
+  data: Data;
+  errorResponse: unknown;
+}
+export interface Data {
+  userId: number;
+  nickname: Nickname;
+}
+export interface Nickname {
+  value: string;
+}
+
+interface RequestInterface {
+  putData: {
+    nickname: string;
+  };
+  token?: string;
+}
+
+const putNicknameAPI = withSessionUser(async ({ putData }: RequestInterface) => {
+  const { data } = await client<Json>({
+    method: 'put',
+    url: '/v1/api/user',
+    data: putData,
+  });
+  return data;
+});
+
+export interface PutNicknameAPIRequest {
+  token?: string;
+}
+
+const PUT_NICKNAME_KEY = () => ['nickname'];
+
+export const usePUTNickname = () => {
+  return useMutation({
+    mutationKey: PUT_NICKNAME_KEY(),
+    mutationFn: putNicknameAPI,
+  });
+};

--- a/app/login/module/api/user.ts
+++ b/app/login/module/api/user.ts
@@ -1,0 +1,38 @@
+import { withSessionUser } from '@/app/common/api/withSessionUser';
+import client from '@/app/common/api/client';
+import { useQuery } from '@tanstack/react-query';
+
+export interface GetUserInfoAPIResponse {
+  isSuccess: boolean;
+  data: Data;
+  errorResponse: unknown;
+}
+export interface Data {
+  userId: number;
+  nickname: Nickname;
+}
+export interface Nickname {
+  value: string;
+}
+
+const getUserInfoAPI = withSessionUser(async () => {
+  const { data } = await client<GetUserInfoAPIResponse>({
+    method: 'get',
+    url: '/v1/api/user',
+    data: {},
+  });
+  return data;
+});
+
+export interface GET_USERINFO_QUERY {
+  token?: string;
+}
+
+const GET_USERINFO_KEY = () => ['get'];
+
+export const useGETUserInfoQuery = () => {
+  return useQuery({
+    queryKey: GET_USERINFO_KEY(),
+    queryFn: () => getUserInfoAPI(),
+  });
+};

--- a/app/login/module/nickname/useHandleNickname.tsx
+++ b/app/login/module/nickname/useHandleNickname.tsx
@@ -1,8 +1,21 @@
+import { useSession } from 'next-auth/react';
+import { useEffect } from 'react';
 import { LoginFunnelProps } from '../../page';
+import { usePUTNickname } from '../api/nickname';
+import { useGETUserInfoQuery } from '../api/user';
 
 interface HandleNicknameProps extends LoginFunnelProps {}
 
 const useHandleNickname = ({ user, setUser, onNext }: HandleNicknameProps) => {
+  const { data: userInfo } = useGETUserInfoQuery();
+
+  useEffect(() => {
+    if (userInfo?.data) {
+      setUser({
+        nickname: userInfo.data.nickname.value,
+      });
+    }
+  }, [userInfo]);
   // USER INTERACTION
   // 1. 유저 > 닉네임 placeholder
   const placeholder = user.nickname.length > 0 ? user.nickname : '닉네임을 입력해주세요';
@@ -15,9 +28,14 @@ const useHandleNickname = ({ user, setUser, onNext }: HandleNicknameProps) => {
   // 2. 유저 > 다음으로
   const isAllFilled = user.nickname.length > 0;
 
+  // 3. 닉네임 저장
+  const { data } = useSession();
+  const { mutate } = usePUTNickname();
+
   const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!isAllFilled) return;
+    mutate({ putData: { nickname: user.nickname }, token: data?.user.accessToken });
     onNext();
   };
 

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useRouter } from 'next/navigation';
-import { Dispatch, SetStateAction, useState } from 'react';
+import { Dispatch, SetStateAction, useMemo, useState } from 'react';
 import { extractNonEmptyArrayKeys } from '../common/hooks/funnel/models';
 import { useFunnel } from '../common/hooks/funnel/useFunnel';
 import navigationPath from '../common/navigation/navigationPath';
@@ -19,10 +19,11 @@ interface User {
 
 const LoginFunnel = () => {
   const router = useRouter();
-  const [Funnel, setStep] = useFunnel(extractNonEmptyArrayKeys(navigationPath.로그인_퍼널));
+  const memoStep = useMemo(() => extractNonEmptyArrayKeys(navigationPath.로그인_퍼널), []);
+  const [Funnel, setStep] = useFunnel(memoStep);
 
   const [user, setUser] = useState<User>({
-    nickname: '빛나는 청룡',
+    nickname: '',
   });
 
   return (
@@ -34,7 +35,7 @@ const LoginFunnel = () => {
         <NicknamePage
           user={user}
           setUser={setUser}
-          onNext={() => router.push(navigationPath.다짐_생성_퍼널.다짐_입력, { scroll: false })}
+          onNext={() => router.replace(navigationPath.다짐_생성_퍼널.다짐_입력, { scroll: false })}
         />
       </Funnel.Step>
     </Funnel>

--- a/app/login/ui/Login/LoginPage.tsx
+++ b/app/login/ui/Login/LoginPage.tsx
@@ -1,23 +1,13 @@
 import BottomFixedButton from '@/app/common/ui/Button/BottomFixedButton';
 import Text from '@/app/common/ui/Text/Text';
-import { signIn, useSession } from 'next-auth/react';
+import { signIn } from 'next-auth/react';
 import Image from 'next/image';
-import { useEffect } from 'react';
 import { LoginFunnelProps } from '../../page';
 import { loginPageStyles } from './login.css';
 
 type LoginPageProps = Omit<LoginFunnelProps, 'user' | 'setUser'>;
 
-const LoginPage = ({ onNext }: LoginPageProps) => {
-  // TODO : 미들웨어 적용
-  const { data: session } = useSession();
-
-  useEffect(() => {
-    if (session?.user.accessToken) {
-      onNext();
-    }
-  }, [session]);
-
+const LoginPage = ({}: LoginPageProps) => {
   const onClickKakaoLogin = () => {
     signIn('kakao', {
       redirect: true,

--- a/app/login/ui/Nickname/NicknamePage.tsx
+++ b/app/login/ui/Nickname/NicknamePage.tsx
@@ -15,6 +15,7 @@ const NicknamePage = ({ user, setUser, onNext }: NicknamePageProps) => {
     setUser,
     onNext,
   });
+
   return (
     <>
       <Header showBackButton />
@@ -33,6 +34,7 @@ const NicknamePage = ({ user, setUser, onNext }: NicknamePageProps) => {
             rows={1}
             withCount={{
               max: 7,
+              initialVisible: true,
             }}
             required
           />

--- a/app/types.ts
+++ b/app/types.ts
@@ -1,8 +1,23 @@
 import 'next-auth';
-import { AuthUser } from './api/auth/[...nextauth]/route';
+import { DefaultSession, DefaultUser } from 'next-auth';
+import type { AuthUser } from './api/auth/[...nextauth]/route';
 
 declare module 'next-auth' {
-  interface Session {
+  interface Session extends DefaultSession {
+    user: AuthUser;
+  }
+
+  interface User extends DefaultUser {
+    userId: number;
+    nickname: string;
+    accessToken: string;
+    refreshToken: string;
+  }
+
+  interface JWT {
+    accessToken: string;
+    accessTokenExpires: number;
+    refreshToken: string;
     user: AuthUser;
   }
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,46 @@
+import { JWT } from 'next-auth';
+import { getToken } from 'next-auth/jwt';
+import { NextRequest, NextResponse } from 'next/server';
+import { AuthUser } from './app/api/auth/[...nextauth]/route';
+import navigationPath from './app/common/navigation/navigationPath';
+
+export { default } from 'next-auth/middleware';
+
+interface CustomToken extends JWT {
+  user: AuthUser;
+}
+
+export async function middleware(req: NextRequest) {
+  const token = (await getToken({ req })) as CustomToken | null;
+
+  const { origin, pathname } = req.nextUrl;
+
+  if (token && token.user.accessToken) {
+    if (!hasQueryParams(req, 'step') && pathname === navigationPath.로그인_퍼널.로그인) {
+      return NextResponse.redirect(`${origin}${navigationPath.로그인_퍼널.닉네임_설정}`);
+    }
+  }
+
+  if (!token) {
+    if (req.nextUrl.pathname.startsWith('/login')) {
+      console.log('Authentication Error');
+      return new NextResponse('Authentication Error', { status: 401 });
+    }
+
+    const { pathname, search, origin, basePath } = req.nextUrl;
+    const signInUrl = new URL(`${basePath}/login`, origin);
+    signInUrl.searchParams.append('callbackUrl', `${basePath}${pathname}${search}`);
+    return NextResponse.redirect(signInUrl);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/', '/login'],
+};
+
+const hasQueryParams = (url: NextRequest, paramName: string) => {
+  const params = new URLSearchParams(url.nextUrl.search);
+  return params.has(paramName);
+};

--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,16 @@ const { createVanillaExtractPlugin } = require('@vanilla-extract/next-plugin');
 const withVanillaExtract = createVanillaExtractPlugin();
 
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  reactStrictMode: false,
+  async rewrites() {
+    return [
+      {
+        source: '/v1/api/:path*',
+        destination: `${process.env.NEXT_PUBLIC_API_URL}/v1/:path*`,
+      },
+    ];
+  },
+};
 
 module.exports = withVanillaExtract(nextConfig);


### PR DESCRIPTION
## 📖 개요

- resolve : #24

## 💻 작업사항

1. 유저 정보 받아오는 api, Query 추가
2. 닉네임 수정 api, Mutation 추가
3. middleware 설정
4. 카카오 로그인 api 연동 및 서버 token 설정 추가
5. axios default client 설정 및 token 검증 로직 추가

## 💡 작성한 이슈 외에 작업한 사항

-

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
