### PR TITLE
feat: 내기 결과 api 연동

### DIFF
--- a/app/(challenge)/(다짐 결과)/result/[goalId]/page.tsx
+++ b/app/(challenge)/(다짐 결과)/result/[goalId]/page.tsx
@@ -2,34 +2,38 @@
 import { extractNonEmptyArrayKeys } from '@/app/common/hooks/funnel/models';
 import { useFunnel } from '@/app/common/hooks/funnel/useFunnel';
 import navigationPath from '@/app/common/navigation/navigationPath';
-import useHandleResult from '../../module/result/useHandleResult';
+import dynamic from 'next/dynamic';
+import { Suspense } from 'react';
 import KakaoDownloadPage from '../../ui/Kakao/KakaoDownloadPage';
-import ResultPage from '../../ui/Result/ResultPage';
 import SavePage from '../../ui/Save/SavePage';
 
 export interface ChallengeResultFunnel {
   onNext: () => void;
 }
 
+const DynamicChallengeResultPage = dynamic(() => import('../../ui/Result/ResultPage'), {
+  ssr: false,
+});
+
 const page = ({ params }: { params: { goalId: number } }) => {
   const [Funnel, setStep] = useFunnel(
     extractNonEmptyArrayKeys(navigationPath.다짐_결과_퍼널(params.goalId)),
   );
 
-  const { steps } = useHandleResult({ setStep, goalId: params.goalId });
-
   return (
-    <>
-      <Funnel>
-        <Funnel.Step name="도전_결과">{steps && <ResultPage steps={steps} />}</Funnel.Step>
-        <Funnel.Step name="도전_결과_저장">
-          <SavePage />
-        </Funnel.Step>
-        <Funnel.Step name="도전_기프티콘">
-          <KakaoDownloadPage />
-        </Funnel.Step>
-      </Funnel>
-    </>
+    <Funnel>
+      <Funnel.Step name="도전_결과">
+        <Suspense>
+          <DynamicChallengeResultPage setStep={setStep} goalId={params.goalId} />
+        </Suspense>
+      </Funnel.Step>
+      <Funnel.Step name="도전_결과_저장">
+        <SavePage />
+      </Funnel.Step>
+      <Funnel.Step name="도전_기프티콘">
+        <KakaoDownloadPage />
+      </Funnel.Step>
+    </Funnel>
   );
 };
 

--- a/app/(challenge)/(다짐 결과)/ui/Result/ResultPage.tsx
+++ b/app/(challenge)/(다짐 결과)/ui/Result/ResultPage.tsx
@@ -1,30 +1,34 @@
-import TransitionComponent, { Step } from '@/app/common/ui/Animated/TransitionComponent';
+import { 다짐_결과_퍼널_Key } from '@/app/common/navigation/navigationPath';
+import TransitionComponent from '@/app/common/ui/Animated/TransitionComponent';
 import Header from '@/app/common/ui/Header/Header';
 import Image from 'next/image';
+import useHandleResult from '../../module/result/useHandleResult';
 import { resultPageStyles } from './result.css';
 
-interface ResultPageProps {}
-
 interface ResultPageProps {
-  steps: Step[];
+  setStep: (key: 다짐_결과_퍼널_Key) => void;
+  goalId: number;
 }
 
-const ResultPage = ({ steps }: ResultPageProps) => {
+const ResultPage = ({ setStep, goalId }: ResultPageProps) => {
+  const { steps } = useHandleResult({ setStep, goalId });
   return (
     <>
       <Header showBackButton />
-      <TransitionComponent steps={steps}>
-        <div className={resultPageStyles.imageWrapper}>
-          <Image
-            src="/images/dog.png"
-            width={100}
-            height={100}
-            layout="responsive"
-            alt="challenge-info"
-            className={resultPageStyles.image}
-          />
-        </div>
-      </TransitionComponent>
+      {steps && (
+        <TransitionComponent steps={steps}>
+          <div className={resultPageStyles.imageWrapper}>
+            <Image
+              src="/images/dog.png"
+              width={100}
+              height={100}
+              layout="responsive"
+              alt="challenge-info"
+              className={resultPageStyles.image}
+            />
+          </div>
+        </TransitionComponent>
+      )}
     </>
   );
 };

--- a/app/(challenge)/(다짐 도전)/module/api/challenge.ts
+++ b/app/(challenge)/(다짐 도전)/module/api/challenge.ts
@@ -16,6 +16,7 @@ export interface Json {
 
 export interface ChallengeData {
   hostUserId: number;
+  hostUserNickname: string;
   id: number;
   type: ChallengeType;
   content: Content;

--- a/app/types.ts
+++ b/app/types.ts
@@ -24,7 +24,7 @@ declare module 'next-auth' {
 }
 
 export type BETTING_TYPE = 'FREE' | 'BILLING';
-export type BETTING_RESULT = 'PROCEEDING' | 'SUCCESS' | 'FAIL';
+export type BETTING_RESULT = 'PROCEEDING' | 'FAIL' | 'GET_GIFTICON' | 'NO_GIFTICON';
 
 declare module '@tanstack/react-query' {
   interface Register {


### PR DESCRIPTION
## 📖 개요

- resolve : #32

## 💻 작업사항

1. 실제 내기 결과를 바탕으로 결과 정보 보여주도록 추가
2. useSuspenseQuery 사용에 따른 dynamic import 적용및 Suspense 추가

## 💡 작성한 이슈 외에 작업한 사항

-

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
